### PR TITLE
Implement ImmutableArray

### DIFF
--- a/src/ImmutableArray.php
+++ b/src/ImmutableArray.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codelicia\Immutable;
+
+use ArrayAccess;
+
+/**
+ * @package Codelicia\Immutable
+ */
+class ImmutableArray implements ArrayAccess
+{
+    private array $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        throw ImmutableArrayException::mutatingArrayIsNotAllowed();
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    public function offsetUnset($offset): bool
+    {
+        throw ImmutableArrayException::mutatingArrayIsNotAllowed();
+    }
+}

--- a/src/ImmutableArrayException.php
+++ b/src/ImmutableArrayException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codelicia\Immutable;
+
+final class ImmutableArrayException extends ImmutableException
+{
+    public static function mutatingArrayIsNotAllowed(): self
+    {
+        return new self('Cannot change an immutable array');
+    }
+}

--- a/src/ImmutableException.php
+++ b/src/ImmutableException.php
@@ -5,12 +5,7 @@ declare(strict_types=1);
 namespace Codelicia\Immutable;
 
 use RuntimeException;
-use function sprintf;
 
-final class ImmutableException extends RuntimeException
+class ImmutableException extends RuntimeException
 {
-    public static function mutatingPropertiesAreNotAllowed(string $propertyName): self
-    {
-        return new self(sprintf('Cannot reassign value to property "%s"', $propertyName));
-    }
 }

--- a/src/ImmutableProperties.php
+++ b/src/ImmutableProperties.php
@@ -72,7 +72,7 @@ trait ImmutableProperties
         $property   = $references[$propertyName];
 
         if ($property->isInitialized()) {
-            throw ImmutableException::mutatingPropertiesAreNotAllowed($propertyName);
+            throw ImmutablePropertiesException::mutatingPropertiesAreNotAllowed($propertyName);
         }
 
         $reflection = $property->reflectionProperty();

--- a/src/ImmutablePropertiesException.php
+++ b/src/ImmutablePropertiesException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codelicia\Immutable;
+
+use function sprintf;
+
+final class ImmutablePropertiesException extends ImmutableException
+{
+    public static function mutatingPropertiesAreNotAllowed(string $propertyName): self
+    {
+        return new self(sprintf('Cannot reassign value to property "%s"', $propertyName));
+    }
+}

--- a/test/functional/cannot-change-nullable-initialized-assignment.phpt
+++ b/test/functional/cannot-change-nullable-initialized-assignment.phpt
@@ -29,4 +29,4 @@ object(User)#3 (1) {
   NULL
 }
 
-Fatal error: Uncaught Codelicia\Immutable\ImmutableException: Cannot reassign value to property "name" %A
+Fatal error: Uncaught Codelicia\Immutable\ImmutablePropertiesException: Cannot reassign value to property "name" %A

--- a/test/functional/cannot-change-private-property-after-assign.phpt
+++ b/test/functional/cannot-change-private-property-after-assign.phpt
@@ -32,4 +32,4 @@ $user->setName('other-name');
 --EXPECTF--
 string(9) "malukenho"
 
-Fatal error: Uncaught Codelicia\Immutable\ImmutableException: Cannot reassign value to property "name" %A
+Fatal error: Uncaught Codelicia\Immutable\ImmutablePropertiesException: Cannot reassign value to property "name" %A

--- a/test/functional/cannot-change-property-after-assign-on-constructor.phpt
+++ b/test/functional/cannot-change-property-after-assign-on-constructor.phpt
@@ -28,4 +28,4 @@ $user->name = 'other-name';
 --EXPECTF--
 string(9) "malukenho"
 
-Fatal error: Uncaught Codelicia\Immutable\ImmutableException: Cannot reassign value to property "name" %A
+Fatal error: Uncaught Codelicia\Immutable\ImmutablePropertiesException: Cannot reassign value to property "name" %A

--- a/test/functional/cannot-change-property-after-assign.phpt
+++ b/test/functional/cannot-change-property-after-assign.phpt
@@ -22,4 +22,4 @@ $user->name = 'other-name';
 --EXPECTF--
 string(9) "malukenho"
 
-Fatal error: Uncaught Codelicia\Immutable\ImmutableException: Cannot reassign value to property "name" %A
+Fatal error: Uncaught Codelicia\Immutable\ImmutablePropertiesException: Cannot reassign value to property "name" %A

--- a/test/functional/cannot-change-property-with-default-assignment.phpt
+++ b/test/functional/cannot-change-property-with-default-assignment.phpt
@@ -20,4 +20,4 @@ $user->name = 'other-name';
 --EXPECTF--
 string(9) "malukenho"
 
-Fatal error: Uncaught Codelicia\Immutable\ImmutableException: Cannot reassign value to property "name" %A
+Fatal error: Uncaught Codelicia\Immutable\ImmutablePropertiesException: Cannot reassign value to property "name" %A

--- a/test/unit/ImmutableArrayTest.php
+++ b/test/unit/ImmutableArrayTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CodeliciaTest\Immutable;
+
+use Codelicia\Immutable\ImmutableArray;
+use Codelicia\Immutable\ImmutableArrayException;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_build_an_immutable_array(): void
+    {
+        $array = [1,2,3];
+
+        $immutableArray = new ImmutableArray($array);
+
+        self::assertInstanceOf(ImmutableArray::class, $immutableArray);
+        self::assertEquals($array[0], $immutableArray[0]);
+        self::assertEquals($array[1], $immutableArray[1]);
+        self::assertEquals($array[2], $immutableArray[2]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_check_if_item_exists(): void
+    {
+        $immutableArray = new ImmutableArray(['first', 'second']);
+
+        self::assertTrue(isset($immutableArray[0]));
+        self::assertTrue(isset($immutableArray[1]));
+        self::assertFalse(isset($immutableArray[2]));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_prevent_to_change_an_item(): void
+    {
+        $immutableArray = new ImmutableArray(['first', 'last']);
+
+        self::expectException(ImmutableArrayException::class);
+        self::expectExceptionMessage('Cannot change an immutable array');
+
+        $immutableArray[1] = 'second'; 
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_prevent_to_set_an_item(): void
+    {
+        $immutableArray = new ImmutableArray(['first', 'last']);
+
+        self::expectException(ImmutableArrayException::class);
+        self::expectExceptionMessage('Cannot change an immutable array');
+
+        $immutableArray[] = 'another'; 
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_prevent_to_unset_an_item(): void
+    {
+        $immutableArray = new ImmutableArray(['first', 'last']);
+
+        self::expectException(ImmutableArrayException::class);
+        self::expectExceptionMessage('Cannot change an immutable array');
+
+        unset($immutableArray[0]);
+    }
+}


### PR DESCRIPTION
Following the immutability subject would be handy to have an immutable array. 

So the first step is to have the ImmutableArray is to implement ArrayAccess. 

A classic array may be passed on constructor to create the ImmutableArray and when a method is used to change the array we will get an Exception.

```php
use namespace Codelicia\Immutable\ImmutableArray;

$onTheFloatingDoor = new ImmutableArray([$rose]);

var_dump($users[0]); // you will see $rose

unset($users[0]); // exception

$onTheFloatingDoor[] = $jack; // exception
```