### PR TITLE
Enable unit tests on phpunit

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,5 +10,8 @@
         <testsuite name="Codelicia\Immutable functional tests">
             <directory suffix=".phpt">./test/functional</directory>
         </testsuite>
+        <testsuite name="Codelicia\Immutable unit tests">
+            <directory>./test/unit</directory>
+        </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
As default configuration phpunit.xml.dist should include integration and
unit tests.

This configuration is used on ci to ensure that everything is "green".